### PR TITLE
Do not trigger onK2CommentsCounter in some cases

### DIFF
--- a/components/com_k2/views/itemlist/view.html.php
+++ b/components/com_k2/views/itemlist/view.html.php
@@ -444,12 +444,12 @@ class K2ViewItemlist extends K2View
 			// Plugins
 			$items[$i] = $model->execPlugins($items[$i], $view, $task);
 
-	            // Trigger comments counter event if needed
-	            if ($params->get('catItemK2Plugins') &&
-                	($params->get('catItemCommentsAnchor') ||
-                 	 $params->get('itemCommentsAnchor') ||
-                 	 $params->get('itemComments')))
-            	    {
+			// Trigger comments counter event if needed
+			if ($params->get('catItemK2Plugins') &&
+			    ($params->get('catItemCommentsAnchor') ||
+			     $params->get('itemCommentsAnchor') ||
+			     $params->get('itemComments')))
+			{
 				// Trigger comments counter event
 				$dispatcher = JDispatcher::getInstance();
 				JPluginHelper::importPlugin('k2');


### PR DESCRIPTION
Hi.

This PR addresses an issue on Item List View when no comments or even comment's counters are to be displayed.

For instance when all of the following Category settings are OFF:
- Anchor link (with comments counter) to item's comment form _[catItemCommentsAnchor]_
- Anchor link (with comments counter) to comment form _[itemCommentsAnchor]_
- Comments _[itemComments]_

the `onK2CommentsCounter()` is still bein triggered causing unnecessary load and processing by 3rd party plugins.

Please accept this PR as w/o it it's killing my website causing unnecessary 550 database queries w/o caching
