### PR TITLE
Eliminating Some "Notices"

### DIFF
--- a/administrator/components/com_k2/models/extrafield.php
+++ b/administrator/components/com_k2/models/extrafield.php
@@ -278,7 +278,7 @@ class K2ModelExtraField extends K2Model
 			}
 
 		}
-
+		$attributes = '';
 		if (version_compare(JVERSION, '3.2', 'ge'))
 		{
 			$arrayAttributes = array();
@@ -289,7 +289,6 @@ class K2ModelExtraField extends K2Model
 		}
 		else
 		{
-			$attributes = '';
 			if ($required)
 			{
 				$attributes .= 'class="k2Required"';


### PR DESCRIPTION
$attributes variable is used again in the function, but in Joomla 3.2+ this variable is undefined, so in Item creation page, we get following Php Notices:
Notice: Undefined variable: attributes in path_to_root\administrator\components\com_k2\models\extrafield.php on line 324(and 347 and 355)
