### PR TITLE
Problem of double encoding

### DIFF
--- a/components/com_k2/helpers/utilities.php
+++ b/components/com_k2/helpers/utilities.php
@@ -165,7 +165,10 @@ class K2HelperUtilities
 	// Cleanup HTML entities
 	public static function cleanHtml($text)
 	{
-		return htmlentities($text, ENT_QUOTES, 'UTF-8', false);
+		if (version_compare(PHP_VERSION, '5.2.3', '<'))
+			return htmlentities(html_entity_decode($text, ENT_QUOTES, 'UTF-8'), ENT_QUOTES, 'UTF-8'); // To prevent double encoding
+		else
+			return htmlentities($text, ENT_QUOTES, 'UTF-8', false);
 	}
 
 	// Gender

--- a/components/com_k2/helpers/utilities.php
+++ b/components/com_k2/helpers/utilities.php
@@ -165,7 +165,7 @@ class K2HelperUtilities
 	// Cleanup HTML entities
 	public static function cleanHtml($text)
 	{
-		return htmlentities($text, ENT_QUOTES, 'UTF-8');
+		return htmlentities($text, ENT_QUOTES, 'UTF-8', false);
 	}
 
 	// Gender


### PR DESCRIPTION
The code to display the image and the link in an article in the files category_item.php, category_item_links.php et item.php uses the function K2HelperUtilities::cleanHtml with $this->item->image_caption or $this->item->title as parameters for the properties "alt" and "title" 

The function K2HelperUtilities::cleanHtml uses the PHP function htmlentities.

The problem is that $this->item->image_caption and $this->item->title have already been encoded once with htmlspecialchars in the file components/com_k2/models/item.php (lignes 232 et 233) causing a double encoding.

I propose to set the "double_encode" parameter to false of the htmlentities function to prevent doubles encodings

I hope my explanations are clear 

Christelle
