### PR TITLE
Update view.html.php: meta name="image" is useless

### DIFF
--- a/components/com_k2/views/itemlist/view.html.php
+++ b/components/com_k2/views/itemlist/view.html.php
@@ -704,7 +704,6 @@ class K2ViewItemlist extends K2View
 		{
 			$image = substr(JURI::root(), 0, -1).str_replace(JURI::root(true), '', $this->category->image);
 			$document->setMetaData('og:image', $image);
-			$document->setMetaData('image', $image);
 		}
 		$document->setMetaData('og:description', strip_tags($document->getDescription()));
 


### PR DESCRIPTION
Hello,
The meta name="image" is useless and doesn't exist.
Better to remove it.
Already claimed here too: https://code.google.com/p/getk2/issues/detail?id=226
