### PR TITLE
Not only strip <script> tags but also strip script code between opene…

### DIFF
--- a/components/com_k2/views/item/view.html.php
+++ b/components/com_k2/views/item/view.html.php
@@ -492,6 +492,7 @@ class K2ViewItem extends K2View
 		else
 		{
 			$metaDescItem = preg_replace("#{(.*?)}(.*?){/(.*?)}#s", '', $item->introtext.' '.$item->fulltext);
+			$metaDescItem = preg_replace("/<script\b[^>]*>(.*?)<\/script>/is", '', $item->introtext.' '.$item->fulltext);
 			$metaDescItem = strip_tags($metaDescItem);
 			$metaDescItem = K2HelperUtilities::characterLimit($metaDescItem, $params->get('metaDescLimit', 150));
 			$document->setDescription(K2_JVERSION == '15' ? $metaDescItem : html_entity_decode($metaDescItem));


### PR DESCRIPTION
…ning and closing <script> tags

Fix for jquery (and other) code showing up as part of the meta description and og: description.

As discussed on forum: http://www.joomlaworks.net/forum/k2-en/45434-meta-and-og-description-improvement