### PR TITLE
Approve ordering url parameter in K2ControllerItemlist

### DIFF
--- a/components/com_k2/controllers/itemlist.php
+++ b/components/com_k2/controllers/itemlist.php
@@ -45,6 +45,7 @@ class K2ControllerItemlist extends K2Controller
 			$urlparams['print'] = 'INT';
 			$urlparams['lang'] = 'CMD';
 			$urlparams['Itemid'] = 'INT';
+			$urlparams['ordering'] = 'CMD';
 		}
 		parent::display($cache, $urlparams);
 	}


### PR DESCRIPTION
Since 'ordering' is a parameter used by K2ModelItemlist to sort records it makes sense to let caching know about it.

Otherwise requests such as:
/component/k2/itemlist?format=json&ordering=hits&limit=10
/component/k2/itemlist?format=json&ordering=date&limit=10
would return the same results since the 2nd request is a cache hit as 'ordering' is not distinguished.