### PR TITLE
Fix doubled up site title in rss feed for Item List [J2.5][J3.x]

### DIFF
--- a/components/com_k2/views/itemlist/view.feed.php
+++ b/components/com_k2/views/itemlist/view.feed.php
@@ -270,7 +270,7 @@ class K2ViewItemlist extends K2View
         {
             $params->set('page_title', $title);
         }
-        if (K2_JVERSION != '15')
+        if (K2_JVERSION == '15')
         {
             if ($mainframe->getCfg('sitename_pagetitles', 0) == 1)
             {


### PR DESCRIPTION
This PR fixes incorrect assertion in Item List rss feed eg:
`if (K2_JVERSION != '15')`

Joomla 1.5 needs this.
Joomla 2.5 is already covering this:
https://github.com/joomla/joomla-cms/blob/2.5.x/libraries/joomla/document/feed/renderer/rss.php#L57-70
Joomla 3.x is already covering this:
https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/document/renderer/feed/rss.php#L56-67

Current implementation results in doubled feed title since both K2 and Joomla set it twice.

Steps to reproduce:
1. Joomla Global Configuration: "Include Site Name in Page Titles" set to "Before"
2. Joomla Global Configuration: "Site Title" set to eg. 'RedShark News'
3. Create a menu item with K2 Item List listing. eg. "Home"
4. Browse for the menu item's feed eg. /home?format=feed

Expected:

``` xml
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
  <channel>
    <title>RedShark News - Home</title>
```

Actual:

``` xml
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
  <channel>
    <title>RedShark News - RedShark News - Home</title>
```
