### PR TITLE
Add onBeforeK2Save and onAfterK2Save triggers upon publishing and unpublishing

### DIFF
--- a/administrator/components/com_k2/models/items.php
+++ b/administrator/components/com_k2/models/items.php
@@ -224,48 +224,61 @@ class K2ModelItems extends K2Model
 
 	function publish()
 	{
-
+		JPluginHelper::importPlugin('k2');
+		JPluginHelper::importPlugin('finder');
+		$dispatcher = JDispatcher::getInstance();
 		$mainframe = JFactory::getApplication();
+		$cache = JFactory::getCache('com_k2');
 		$cid = JRequest::getVar('cid');
+
 		foreach ($cid as $id)
 		{
 			$row = JTable::getInstance('K2Item', 'Table');
 			$row->load($id);
 			$row->published = 1;
-			$row->store();
+
+			$dispatcher->trigger('onBeforeK2Save', array(&$row, false));
+			if ($row->store()) {
+				$dispatcher->trigger('onAfterK2Save', array(&$row, false));
+			}
 		}
-		JPluginHelper::importPlugin('finder');
-		$dispatcher = JDispatcher::getInstance();
+
 		$dispatcher->trigger('onFinderChangeState', array(
 			'com_k2.item',
 			$cid,
 			1
 		));
-		$cache = JFactory::getCache('com_k2');
+
 		$cache->clean();
 		$mainframe->redirect('index.php?option=com_k2&view=items');
 	}
 
 	function unpublish()
 	{
-
+		JPluginHelper::importPlugin('k2');
+		JPluginHelper::importPlugin('finder');
+		$dispatcher = JDispatcher::getInstance();
 		$mainframe = JFactory::getApplication();
+		$cache = JFactory::getCache('com_k2');
 		$cid = JRequest::getVar('cid');
+
 		foreach ($cid as $id)
 		{
 			$row = JTable::getInstance('K2Item', 'Table');
 			$row->load($id);
 			$row->published = 0;
-			$row->store();
+
+			$dispatcher->trigger('onBeforeK2Save', array(&$row, false));
+			if ($row->store()) {
+				$dispatcher->trigger('onAfterK2Save', array(&$row, false));
+			}
 		}
-		JPluginHelper::importPlugin('finder');
-		$dispatcher = JDispatcher::getInstance();
 		$dispatcher->trigger('onFinderChangeState', array(
 			'com_k2.item',
 			$cid,
 			0
 		));
-		$cache = JFactory::getCache('com_k2');
+
 		$cache->clean();
 		$mainframe->redirect('index.php?option=com_k2&view=items');
 	}


### PR DESCRIPTION
Proposing adding these two triggers since both publish() and unpublish() admin actions cause the item to change state.

I would strongly appreciate merging this PR. My use cases are:
1. Once an article is approved by publisher, a notification is emailed to its author.
2. Once an article is approved, plugins trigger other social actions like publishing to twitter, FB etc..

NOTE: I am not aware how this change impacts 3rd party plugins that rely upon onBeforeK2Save/onAfterK2Save.
