### PR TITLE
Don't expose html entities to description

### DIFF
--- a/components/com_k2/views/item/view.html.php
+++ b/components/com_k2/views/item/view.html.php
@@ -492,9 +492,10 @@ class K2ViewItem extends K2View
 		else
 		{
 			$metaDescItem = preg_replace("#{(.*?)}(.*?){/(.*?)}#s", '', $item->introtext.' '.$item->fulltext);
-			$metaDescItem = strip_tags($metaDescItem);
+			$metaDescItem = K2_JVERSION == '15' ? $metaDescItem : html_entity_decode($metaDescItem);
+			$metaDescItem = trim(strip_tags($metaDescItem));
 			$metaDescItem = K2HelperUtilities::characterLimit($metaDescItem, $params->get('metaDescLimit', 150));
-			$document->setDescription(K2_JVERSION == '15' ? $metaDescItem : html_entity_decode($metaDescItem));
+			$document->setDescription($metaDescItem);
 		}
 		if ($item->metakey)
 		{


### PR DESCRIPTION
With the following article contents:

``` html
<p>How to use new html5 &lt;main&gt;tag&lt;/main&gt;</p>
```

this piece of code https://github.com/getk2/k2/blob/master/components/com_k2/views/item/view.html.php#L494-497 would create:

``` html
<meta property="og:description" content="How to use new html5 tag" />
<meta name="description" content="How to use new html5 &lt;main&gt;tag&lt;/main&gt;">
```

For consistency I suggest we strip the entities AFTER decoding to follow what "og:description" does.
