### PR TITLE
Optimize image processing

### DIFF
--- a/administrator/components/com_k2/models/item.php
+++ b/administrator/components/com_k2/models/item.php
@@ -309,7 +309,10 @@ class K2ModelItem extends K2Model
 
 				//Original image
 				$savepath = JPATH_SITE.DS.'media'.DS.'k2'.DS.'items'.DS.'src';
-				$handle->image_convert = 'jpg';
+				if ($handle->image_src_type !== 'jpg') {
+					// Only process the original image if it's not jpg already
+					$handle->image_convert = 'jpg';
+				}
 				$handle->jpeg_quality = 100;
 				$handle->file_auto_rename = false;
 				$handle->file_overwrite = true;
@@ -336,6 +339,11 @@ class K2ModelItem extends K2Model
 					$imageWidth = $params->get('itemImageXL', '800');
 				}
 				$handle->image_x = $imageWidth;
+				if ($handle->image_src_type === 'jpg' && $handle->image_src_x == $imageWidth) {
+					// Preserve the original image if it's jpg already with the size we need
+					$handle->image_resize = false;
+					$handle->image_convert = '';
+				}
 				$handle->Process($savepath);
 
 				//Large image
@@ -355,6 +363,11 @@ class K2ModelItem extends K2Model
 					$imageWidth = $params->get('itemImageL', '600');
 				}
 				$handle->image_x = $imageWidth;
+				if ($handle->image_src_type === 'jpg' && $handle->image_src_x == $imageWidth) {
+					// Preserve the original image if it's jpg already with the size we need
+					$handle->image_resize = false;
+					$handle->image_convert = '';
+				}
 				$handle->Process($savepath);
 
 				//Medium image
@@ -374,6 +387,11 @@ class K2ModelItem extends K2Model
 					$imageWidth = $params->get('itemImageM', '400');
 				}
 				$handle->image_x = $imageWidth;
+				if ($handle->image_src_type === 'jpg' && $handle->image_src_x == $imageWidth) {
+					// Preserve the original image if it's jpg already with the size we need
+					$handle->image_resize = false;
+					$handle->image_convert = '';
+				}
 				$handle->Process($savepath);
 
 				//Small image
@@ -393,6 +411,11 @@ class K2ModelItem extends K2Model
 					$imageWidth = $params->get('itemImageS', '200');
 				}
 				$handle->image_x = $imageWidth;
+				if ($handle->image_src_type === 'jpg' && $handle->image_src_x == $imageWidth) {
+					// Preserve the original image if it's jpg already with the size we need
+					$handle->image_resize = false;
+					$handle->image_convert = '';
+				}
 				$handle->Process($savepath);
 
 				//XSmall image
@@ -412,6 +435,11 @@ class K2ModelItem extends K2Model
 					$imageWidth = $params->get('itemImageXS', '100');
 				}
 				$handle->image_x = $imageWidth;
+				if ($handle->image_src_type === 'jpg' && $handle->image_src_x == $imageWidth) {
+					// Preserve the original image if it's jpg already with the size we need
+					$handle->image_resize = false;
+					$handle->image_convert = '';
+				}
 				$handle->Process($savepath);
 
 				//Generic image
@@ -424,6 +452,11 @@ class K2ModelItem extends K2Model
 				$handle->file_new_name_body = $filename.'_Generic';
 				$imageWidth = $params->get('itemImageGeneric', '300');
 				$handle->image_x = $imageWidth;
+				if ($handle->image_src_type === 'jpg' && $handle->image_src_x == $imageWidth) {
+					// Preserve the original image if it's jpg already with the size we need
+					$handle->image_resize = false;
+					$handle->image_convert = '';
+				}
 				$handle->Process($savepath);
 
 				if ($files['image']['error'] == 0)

--- a/administrator/components/com_k2/models/item.php
+++ b/administrator/components/com_k2/models/item.php
@@ -317,6 +317,7 @@ class K2ModelItem extends K2Model
 				$handle->file_auto_rename = false;
 				$handle->file_overwrite = true;
 				$handle->file_new_name_body = md5("Image".$row->id);
+				$handle->file_new_name_ext = 'jpg';
 				$handle->Process($savepath);
 
 				$filename = $handle->file_dst_name_body;
@@ -330,6 +331,7 @@ class K2ModelItem extends K2Model
 				$handle->file_auto_rename = false;
 				$handle->file_overwrite = true;
 				$handle->file_new_name_body = $filename.'_XL';
+				$handle->file_new_name_ext = 'jpg';
 				if (JRequest::getInt('itemImageXL'))
 				{
 					$imageWidth = JRequest::getInt('itemImageXL');
@@ -354,6 +356,7 @@ class K2ModelItem extends K2Model
 				$handle->file_auto_rename = false;
 				$handle->file_overwrite = true;
 				$handle->file_new_name_body = $filename.'_L';
+				$handle->file_new_name_ext = 'jpg';
 				if (JRequest::getInt('itemImageL'))
 				{
 					$imageWidth = JRequest::getInt('itemImageL');
@@ -378,6 +381,7 @@ class K2ModelItem extends K2Model
 				$handle->file_auto_rename = false;
 				$handle->file_overwrite = true;
 				$handle->file_new_name_body = $filename.'_M';
+				$handle->file_new_name_ext = 'jpg';
 				if (JRequest::getInt('itemImageM'))
 				{
 					$imageWidth = JRequest::getInt('itemImageM');
@@ -402,6 +406,7 @@ class K2ModelItem extends K2Model
 				$handle->file_auto_rename = false;
 				$handle->file_overwrite = true;
 				$handle->file_new_name_body = $filename.'_S';
+				$handle->file_new_name_ext = 'jpg';
 				if (JRequest::getInt('itemImageS'))
 				{
 					$imageWidth = JRequest::getInt('itemImageS');
@@ -426,6 +431,7 @@ class K2ModelItem extends K2Model
 				$handle->file_auto_rename = false;
 				$handle->file_overwrite = true;
 				$handle->file_new_name_body = $filename.'_XS';
+				$handle->file_new_name_ext = 'jpg';
 				if (JRequest::getInt('itemImageXS'))
 				{
 					$imageWidth = JRequest::getInt('itemImageXS');


### PR DESCRIPTION
Once an article image is attached this PR will do the following:
1. Only process the original image if it's not jpg already thus keeping the original image instead of forcing to resample it. This is important for hight contrast images (eg. dark text on light background) and also for any other reason where you want to keep the original image if eg. you change the size of the XLarge at some point and use a script to re-size all images thus you need to original image.
2. For other images which are scaled, avoid re-sampling if the uploaded image is jpg already with the size we want to rescale to. Example: XLarge image is set to 1600px, you upload a 1600x1200 jpg and due to high contrast ratio of the image you want to use the originally uploaded image as XLarge avoiding any kind of adjusting and resampling for XLarge only.
