### PR TITLE
The query was producing duplicate items.

### DIFF
--- a/modules/mod_k2_content/helper.php
+++ b/modules/mod_k2_content/helper.php
@@ -93,7 +93,7 @@ class modK2ContentHelper
 
 		else
 		{
-			$query = "SELECT i.*,";
+			$query = "SELECT DISTINCT i.*,";
 
 			if ($ordering == 'modified')
 			{


### PR DESCRIPTION
Used DISTINCT in order to pull distinct items when the query tries to pull items from multiple tags.
If an item was appearing in two or more tags which were selected in the module's settings it would appear x times in the list.