### PR TITLE
Router update.

### DIFF
--- a/components/com_k2/router.php
+++ b/components/com_k2/router.php
@@ -148,7 +148,28 @@ if ($params->get('k2Sef'))
 				// Replace the item with the category slug
 				if ($params->get('k2SefLabelItem') == '1')
 				{
-					$segments[0] = getCategorySlug((int)$ItemId);
+
+					// Remove the id from the slug
+					if ($params->get('k2SefInsertCatId') == '0')
+					{
+						
+						// Try to split the slug
+						$segments[0] = getCategorySlug((int)$ItemId);
+						$temp 	 	 = @explode('-', $segments[0]);
+
+						// If the slug contained an item id do not use it
+						if (count($temp) > 1)
+						{
+							@$segments[0] = $temp[1];
+						}
+
+					}
+					else 
+					{
+						// Apply the link including the id
+						$segments[0] = getCategorySlug((int)$ItemId);
+					}
+
 				}
 				else
 				{


### PR DESCRIPTION
The category's id could not be stripped from the item's URL.
Addresses - https://github.com/getk2/k2/issues/316
Sauce here: http://www.joomlaworks.net/forum/k2-en/46301-remove-category-alias-from-url