### PR TITLE
Account for user timezone when saving item

### DIFF
--- a/administrator/components/com_k2/models/item.php
+++ b/administrator/components/com_k2/models/item.php
@@ -128,7 +128,12 @@ class K2ModelItem extends K2Model
 		}
 
 		$config = JFactory::getConfig();
-		$tzoffset = K2_JVERSION == '30' ? $config->get('offset') : $config->getValue('config.offset');
+		if ($userTimezone = $user->getParam('timezone')) {
+            		$tzoffset = new DateTimeZone($userTimezone);
+        	} else {
+        		$tzoffset = K2_JVERSION == '30' ? $config->get('offset') : $config->getValue('config.offset');
+        	}
+
 		$date = JFactory::getDate($row->created, $tzoffset);
 		$row->created = K2_JVERSION == '15' ? $date->toMySQL() : $date->toSql();
 


### PR DESCRIPTION
Some dates in $row input are supposed to be in user-time, so we must convert to server time correctly.

Let me give you short background. My websites are configured to GMT in multi-user environment where authors and editors work in different timezones. Each author and editor has appropriate timezone configured in Joomla account.

Here is what I would expect:
- User picks up `Creation date`, `Start publishing`, `Finish publishing` dates in calendar according to their local time
- The date is converted from the user timezone (configured in Joomla user) to GMT and stored in the database
- These date are then converted back to usertime upon rendering the input fields in K2ViewItem::diesplay():

``` php
$lists['createdCalendar'] = JHTML::_('calendar', $created, 'created', 'created', '%Y-%m-%d %H:%M:%S');
$lists['publish_up'] = JHTML::_('calendar', $publishUp, 'publish_up', 'publish_up', '%Y-%m-%d %H:%M:%S');
$lists['publish_down'] = JHTML::_('calendar', $publishDown, 'publish_down', 'publish_down', '%Y-%m-%d %H:%M:%S');
```

What actually happens:
K2ModelItem::save() assumes that `$row->created`, `$row->publish_up` and `$row->publish_down` were entered in Joomla offset (eg. `$config->get('offset')`) which results in the dates being converted incorrectly. Upon rendering the calendar JHTML::_ input field convert the incorrect date to usertime resulting in the datetime being always ahead of what the user entered by the difference offset.

To reproduce:
- Set UTC Joomla timezone
- Set custom timezone for your Joomla user
- Create or edit existing article amending one of the dates mentioned above.

I can't expect editors or authors to calculate the differences between timezones this should be done automatically for them under the hood.
