### PR TITLE
Fixes the include path to find the correct model

### DIFF
--- a/administrator/components/com_k2/views/item/view.html.php
+++ b/administrator/components/com_k2/views/item/view.html.php
@@ -40,7 +40,7 @@ class K2ViewItem extends K2View
 			]
 		";
 		$document->addScriptDeclaration($js);
-		K2Model::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR.DS.'models');
+		K2Model::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR.DS.'models', 'K2Model');
 		$model = K2Model::getInstance('Item', 'K2Model', array('table_path' => JPATH_COMPONENT_ADMINISTRATOR.DS.'tables'));
 		$item = $model->getData();
 		JFilterOutput::objectHTMLSafe($item, ENT_QUOTES, array(


### PR DESCRIPTION
Related to: https://github.com/getk2/k2/issues/130

I don't seem to be able to reproduce on all the k2 installations, but I found out the same issue on a client's site.
Basically, If you don't specify the prefix param it won't find the correct model in the frontend while trying to edit a form.
Note that on line 44 it specifies the prefix on the getInstance, and that prefix will be used as key on the paths array. Without this fix, it seems like the line 43 is useless since it will add a path to somewhere it won't be found.

After debugging I found out that when you call the task item.add, it will load the view K2ViewItem from the admin. That is ok, but inside the view it is loading the wrong model class.

You can check that on this line:
https://github.com/andergmartins/k2/blob/master/administrator/components/com_k2/views/item/view.html.php#L44 we get the instance of the module, specifying the class prefix: K2Model. That is correct. But on the line https://github.com/andergmartins/k2/blob/master/administrator/components/com_k2/views/item/view.html.php#L43 we don't add the path to the correct prefix, since there is no prefix.
According to my tests, if you omit the prefix, the line 44 will result in an instance of the frontend module (which path is already there, since we are on the frontend) instead of the model from the backend. It is clear that we are expecting a model from the backend because we are calling methods like isCheckedOut which is only available on the class provide by the backend.
