### PR TITLE
line 527 generates error when there is no comments

### DIFF
--- a/components/com_k2/models/item.php
+++ b/components/com_k2/models/item.php
@@ -524,7 +524,7 @@ class K2ModelItem extends K2Model
 				$row->author->profile->url = htmlspecialchars($row->author->profile->url, ENT_QUOTES, 'UTF-8');
 			}
 		}
-		$row->numOfComments = $item->numOfComments;
+		if (isset($item->numOfComments)) $row->numOfComments = $item->numOfComments;
 		$row->events = $item->event;
 		$row->language = $item->language;
 		return $row;


### PR DESCRIPTION
Fixed a problem where in JSON view, when there are no comments, such notice will be generated:
"Undefined property: stdClass::$numOfComments in /components/com_k2/models/item.php on line 527"
