### PR TITLE
Update to element.php to keep 'object' in the request when paginating

### DIFF
--- a/administrator/components/com_k2/views/items/tmpl/element.php
+++ b/administrator/components/com_k2/views/items/tmpl/element.php
@@ -81,4 +81,5 @@ defined('_JEXEC') or die;
 	<input type="hidden" name="tmpl" value="component" />
 	<input type="hidden" name="filter_order" value="<?php echo $this->lists['order']; ?>" />
 	<input type="hidden" name="filter_order_Dir" value="<?php echo $this->lists['order_Dir']; ?>" />
+	<input type="hidden" name="object" value="<?php echo JRequest::getCmd('object', 'id'); ?>" />
 </form>


### PR DESCRIPTION
'object' (which is in the request) is lost when paginating through items (actually, any time there is a refresh in the modal window), resulting in the item selected not being picked up when properly coding an 'item' custom field to allow for multiple occurrences on a page. When there is just one 'item' custom field (original from core K2), the bug gets unnoticed (since 'object' is never used in jSelectItem of the 'item' custom field).
