### PR TITLE
Fix languageFilter query in K2 Comments Module

### DIFF
--- a/modules/mod_k2_comments/helper.php
+++ b/modules/mod_k2_comments/helper.php
@@ -83,7 +83,7 @@ class modK2CommentsHelper
         }
 
         if ($languageFilter) {
-            $query .= " AND i.language IN ({$languageFilter}) AND c.language IN ({$languageFilter})";
+            $query .= " AND i.language IN ({$languageFilter}) AND category.language IN ({$languageFilter})";
         }
 
         $query .= " GROUP BY i.id ORDER BY c.commentDate DESC";


### PR DESCRIPTION
Fix 1054 error
```1054 - Unknown column 'c.language' in 'where clause'```

I apologize for the name of the commit, changed the file directly to github and forgot to change the automatic naming