### PR TITLE
persian / jalali Calendar bug

### DIFF
--- a/administrator/components/com_k2/views/item/tmpl/default.php
+++ b/administrator/components/com_k2/views/item/tmpl/default.php
@@ -937,16 +937,14 @@ defined('_JEXEC') or die;
 								<label><?php echo JText::_('K2_CREATION_DATE'); ?></label>
 							</div>
 							<div class="paramValue k2DateTimePickerControl">
-								<input type="text" data-k2-datetimepicker id="created" name="created" value="<?php echo $this->lists['createdCalendar']; ?>" autocomplete="off" />
-								<i class="fa fa-calendar" aria-hidden="true"></i>
+								<?php echo $this->lists['createdCalendar']; ?>
 							</div>
 						<li>
 						    <div class="paramLabel">
 								<label><?php echo JText::_('K2_START_PUBLISHING'); ?></label>
 							</div>
 							<div class="paramValue k2DateTimePickerControl">
-								<input type="text" data-k2-datetimepicker id="publish_up" name="publish_up" value="<?php echo $this->lists['publish_up']; ?>" autocomplete="off" />
-								<i class="fa fa-calendar" aria-hidden="true"></i>
+								<?php echo $this->lists['publish_up']; ?>
 							</div>
 						</li>
 						<li>
@@ -954,8 +952,7 @@ defined('_JEXEC') or die;
 								<label><?php echo JText::_('K2_FINISH_PUBLISHING'); ?></label>
 							</div>
 							<div class="paramValue k2DateTimePickerControl">
-								<input type="text" data-k2-datetimepicker id="publish_down" name="publish_down" value="<?php echo $this->lists['publish_down']; ?>" autocomplete="off" />
-								<i class="fa fa-calendar" aria-hidden="true"></i>
+								<?php echo $this->lists['publish_up']; ?>
 							</div>
 						</li>
 					</ul>

--- a/administrator/components/com_k2/views/item/view.html.php
+++ b/administrator/components/com_k2/views/item/view.html.php
@@ -107,20 +107,20 @@ class K2ViewItem extends K2View
 
         // Date/time
         $created = $item->created;
-        $publishUp = $item->publish_up;
-        $publishDown = $item->publish_down;
+		$publishUp = $item->publish_up;
+		if ((int)$item->publish_down)
+		{
+			$publishDown = $item->publish_down;
+		}
+		else
+		{
+			$publishDown = '';
+		}
 
-        $created = JHTML::_('date', $item->created, $dateFormat);
-        $publishUp = JHTML::_('date', $item->publish_up, $dateFormat);
-        if ((int)$item->publish_down) {
-            $publishDown = JHTML::_('date', $item->publish_down, $dateFormat);
-        } else {
-            $publishDown = '';
-        }
-
-        $lists['createdCalendar'] = $created;
-        $lists['publish_up'] = $publishUp;
-        $lists['publish_down'] = $publishDown;
+       // Set up calendars
+		$lists['createdCalendar'] = JHTML::_('calendar', $created, 'created', 'created', $dateFormat);
+		$lists['publish_up'] = JHTML::_('calendar', $publishUp, 'publish_up', 'publish_up', $dateFormat);
+		$lists['publish_down'] = JHTML::_('calendar', $publishDown, 'publish_down', 'publish_down', $dateFormat);
 
         if ($item->id) {
             $lists['created'] = JHTML::_('date', $item->created, JText::_('DATE_FORMAT_LC2'));


### PR DESCRIPTION
i find out that the new calendar of k2 uses Flatpickr.
but Flatpickr just support Gregorian calendar and the date of creation and publication will store wrongly in database when we use k2 in other language like persian that uses Persian Calendar .
So I suggest that you use the Joomla Calendar like before.