### PR TITLE
Trigger save events when an item is featured

### DIFF
--- a/administrator/components/com_k2/controllers/items.php
+++ b/administrator/components/com_k2/controllers/items.php
@@ -114,8 +114,38 @@ class K2ControllerItems extends K2Controller
     public function featured()
     {
         JRequest::checkToken() or jexit('Invalid Token');
-        $model = $this->getModel('items');
-        $model->featured();
+        $app = JFactory::getApplication();
+
+        $ids = JRequest::getVar('cid', [], 'default', 'array');
+        $ids = array_values(
+            array_unique(
+                array_filter(
+                    array_map('intval', $ids),
+                    function ($value)
+                    {
+                        return (int) $value > 0;
+                    }
+                )
+            )
+        );
+
+        if ($ids)
+        {
+            $model = $this->getModel('item');
+
+            foreach ($ids as $id)
+            {
+                $model->toggleFeatured($id);
+            }
+
+            $app->enqueueMessage(JText::_('K2_ITEMS_CHANGED'));
+        }
+
+        if (JRequest::getCmd('context') == "modalselector") {
+            $app->redirect('index.php?option=com_k2&view=items&tmpl=component&context=modalselector');
+        } else {
+            $app->redirect('index.php?option=com_k2&view=items');
+        }
     }
 
     public function trash()

--- a/administrator/components/com_k2/lib/src/Traits/HasEvents.php
+++ b/administrator/components/com_k2/lib/src/Traits/HasEvents.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * @version    2.10.x
+ * @package    K2
+ * @author     JoomlaWorks https://www.joomlaworks.net
+ * @copyright  Copyright (c) 2006 - 2019 JoomlaWorks Ltd. All rights reserved.
+ * @license    GNU/GPL license: https://www.gnu.org/copyleft/gpl.html
+ */
+
+namespace K2\Traits;
+
+defined('_JEXEC') || die;
+
+/**
+ * Methods for entities that have events.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+trait HasEvents
+{
+	/**
+	 * Plugin types already imported.
+	 *
+	 * @var  array
+	 */
+	protected $pluginsImported = [];
+
+	/**
+	 * Event plugins that will be imported by default.
+	 *
+	 * @return  array
+	 */
+	public function getDefaultEventsPlugins()
+	{
+		return ['k2', 'content'];
+	}
+
+	/**
+	 * Check if
+	 *
+	 * @param   string   $type  Plugin type
+	 *
+	 * @return  boolean
+	 */
+	public function hasImportedPlugin($type)
+	{
+		return in_array($type, $this->pluginsImported, true);
+	}
+
+	/**
+	 * Import an events plugin type.
+	 *
+	 * @param   string  $name  Plugin type.
+	 *
+	 * @return  void
+	 */
+	public function importPlugin($name)
+	{
+		return $this->importPlugins((array) $name);
+	}
+
+	/**
+	 * Import plugin types.
+	 *
+	 * @param   string  $types  Plugin types.
+	 *
+	 * @return  void
+	 */
+	public function importPlugins(array $types)
+	{
+		$types = array_filter(
+			$types,
+			function ($type)
+			{
+				return '' !== trim($type);
+			}
+		);
+
+		foreach ($types as $type)
+		{
+			\JPluginHelper::importPlugin($type);
+
+			$this->eventsPluginsImported[] = $type;
+		}
+	}
+
+	/**
+	 * Trigger an event.
+	 *
+	 * @param   string  $event        Name of the event to trigger
+	 * @param   array   $params       Event parameters
+	 * @param   array   $pluginTypes  Plugin types
+	 *
+	 * @return  array
+	 */
+	public function triggerEvent($event, array $params = [], array $pluginTypes = [])
+	{
+		$pluginTypes = $pluginTypes ?: $this->getDefaultEventsPlugins();
+
+		$this->importPlugins($pluginTypes);
+
+		$dispatcher = \JDispatcher::getInstance();
+
+		return $dispatcher->trigger($event, $params);
+	}
+}

--- a/administrator/components/com_k2/models/model.php
+++ b/administrator/components/com_k2/models/model.php
@@ -9,11 +9,15 @@
 
 defined('_JEXEC') or die;
 
+use K2\Traits\HasEvents;
+
 jimport('joomla.application.component.model');
 
 if (version_compare(JVERSION, '2.5', 'ge')) {
     class K2Model extends JModelLegacy
     {
+        use HasEvents;
+
         public static function addIncludePath($path = '', $prefix = 'K2Model')
         {
             return parent::addIncludePath($path, $prefix);
@@ -22,6 +26,8 @@ if (version_compare(JVERSION, '2.5', 'ge')) {
 } else {
     class K2Model extends JModel
     {
+        use HasEvents;
+
         public function addIncludePath($path = '', $prefix = 'K2Model')
         {
             return parent::addIncludePath($path);

--- a/plugins/system/k2.php
+++ b/plugins/system/k2.php
@@ -16,6 +16,14 @@ class plgSystemK2 extends JPlugin
 {
     public function onAfterInitialise()
     {
+        \JLoader::registerNamespace(
+            'K2',
+            JPATH_ADMINISTRATOR . '/components/com_k2/lib/src',
+            false,
+            false,
+            'psr4'
+        );
+
         // Determine Joomla version
         if (version_compare(JVERSION, '3.0', 'ge')) {
             define('K2_JVERSION', '30');


### PR DESCRIPTION
Currently items trigger events when they are saved or published/unpublished but there are some cases where we need to connect logic when an item is featured/unfeatured. This makes it happen in a B/C way.

There are other changes I did:

### Avoid controller logic in model method.

Change K2ControllerItems::featured() logic to process request, add system messages and perform redirections.

A model should never access request parameters directly. This is something to be done in controllers to allow reusing model methods everywhere. Now if you want to use $itemsModel->featured() anywhere to feature X items you cannot really do it because it requires parameters from request. 

Same for system messages. You may want to feature events but notify users by email or even not notifying them for an internal process. Using this logic in the model forces system messages to be added.

Same for redirections. A model should never redirect anybody anywhere. It's part of the controllers' job.

### Register K2 namespace and start using it.

This PR registers `K2` namespace in `administrator/components/com_k2/lib/src`. I think you should really ship a library with K2 and register namespace there but I didn't want to deal with that now and make this pull request harder to merge.

### K2\Traits\HasEvents trait.

This creates a `K2\Traits\HasEvents` trait that allows to unify the way events are triggered in all the models. It can save you a lot of lines of code and make event handling easier to handle/test. Converts this:

```php
	JPluginHelper::importPlugin('finder');
	$dispatcher = JDispatcher::getInstance();

	$result = $dispatcher->trigger('onFinderAfterSave', array($row, $isNew));
```

into this: 

```php
	$result = $this->triggerEvent('onFinderAfterSave', [$row, $isNew], ['finder']);
```

Also let's say that the dispatcher class is changed in joomla. You only have 1 place to adjust.

That trait is injected in the base K2Model so it's available to be used in all the models. I haven't changed any model event to avoid blocking this PR but it should be easy to do and will allow you to remove a lot of code.


