### PR TITLE
FIX `Can't use method return value in write context` for PHP < 5.5

### DIFF
--- a/components/com_k2/views/item/view.html.php
+++ b/components/com_k2/views/item/view.html.php
@@ -465,7 +465,8 @@ class K2ViewItem extends K2View
 
             // Set <title>
             if ($menuItemMatch) {
-                if (empty($params->get('page_title'))) {
+                $page_title = $params->get('page_title');
+                if (empty($page_title)) {
                     $params->set('page_title', $item->rawTitle);
                 }
             } else {


### PR DESCRIPTION
Fix #506

----

Fatal error: Can't use method return value in write context in /htmlbase/components/com_k2/views/item/view.html.php on line 468.

This comes from the use of  `empty()` on a return value.
`empty()` can only be used on return from PHP>=5.5. (https://www.php.net/manual/en/function.empty.php)

Since Joomla! is still compatible with PHP 5.3.10+ (https://downloads.joomla.org/technical-requirements). I suggest we do the same here.