### PR TITLE
Fix ignoring AND in case of index.php?option=com_search&view=search&s…

### DIFF
--- a/plugins/search/k2.php
+++ b/plugins/search/k2.php
@@ -149,7 +149,7 @@ class plgSearchK2 extends JPlugin
                     CASE WHEN CHAR_LENGTH(c.alias) THEN CONCAT_WS(':', c.id, c.alias) ELSE c.id END as catslug
                 FROM #__k2_items AS i
                 INNER JOIN #__k2_categories AS c ON c.id = i.catid
-                WHERE {$where}
+                WHERE ({$where})
                     AND i.trash = 0
                     AND i.published = 1
                     AND i.access {$accessCheck}


### PR DESCRIPTION
if menu item ihave type index.php?option=com_search&view=search&searchword=blabla

For now there`s bug cause AND parts are working as OR and doesnt work