### PR TITLE
fix(usergroup): Fix PHP 8 array_merge(): Argument #1 must be of...

### DIFF
--- a/administrator/components/com_k2/views/usergroup/view.html.php
+++ b/administrator/components/com_k2/views/usergroup/view.html.php
@@ -47,7 +47,6 @@ class K2ViewUserGroup extends K2View
         require_once JPATH_ADMINISTRATOR.'/components/com_k2/models/categories.php';
         $categoriesModel = K2Model::getInstance('Categories', 'K2Model');
         $categories = $categoriesModel->categoriesTree(null, true);
-        $categories_options = @array_merge($categories_option, $categories);
         $lists['categories'] = JHTML::_('select.genericlist', $categories, 'params[categories][]', 'multiple="multiple" size="15"', 'value', 'text', $appliedCategories);
         $lists['inheritance'] = JHTML::_('select.booleanlist', 'params[inheritance]', null, $inheritance);
         $this->assignRef('lists', $lists);


### PR DESCRIPTION

For more info: https://www.joomlaworks.net/forum/k2-en/64037-php-8,-new-group-array_merge-argument-1-must-be-of-type-array,-null-given#179759

