### PR TITLE
Allow limitstart to be set as a parameter

### DIFF
--- a/modules/mod_k2_content/helper.php
+++ b/modules/mod_k2_content/helper.php
@@ -31,7 +31,11 @@ class modK2ContentHelper
         $limit = $params->get('itemCount', 5);
         $cid = $params->get('category_id', null);
         $ordering = $params->get('itemsOrdering', '');
-        $limitstart = JRequest::getInt('limitstart');
+        
+        $limitstart = $params->get('limitStart', 0);
+        if (JRequest::getVar('limitstart') !== null) {
+            $limitstart = JRequest::getInt('limitstart');
+        }
 
         // Get ACL
         $user = JFactory::getUser();


### PR DESCRIPTION
Hi, we're using the module helper to load items in our yootheme pro builder integration for k2.
We saw that the limit start gets only taken from the url, while we would like to be able to pass it as a parameter.
I've added this feature, while keeping the forced loading from the url if present, in order not to break the pagination stuff