### PR TITLE
Ordering the tag list in item form make much more easier to cherry picking the right tag

### DIFF
--- a/administrator/components/com_k2/models/item.php
+++ b/administrator/components/com_k2/models/item.php
@@ -984,6 +984,7 @@ class K2ModelItem extends K2Model
         if (!is_null($itemID)) {
             $query .= " WHERE tags.id NOT IN (SELECT tagID FROM #__k2_tags_xref WHERE itemID=".(int) $itemID.")";
         }
+        $query .= " ORDER BY name ASC";
         $db->setQuery($query);
         $rows = $db->loadObjectList();
         return $rows;


### PR DESCRIPTION
Sort tag list by name ascending
It is very inconvenient to find the desired tag when the list is very long.  This makes it easier to explore the set of available tags